### PR TITLE
Fix/rss wrong post links

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -6,7 +6,7 @@ export default defineConfig({
   // used to generate images
   site:
     process.env.VERCEL_ENV === 'production'
-      ? 'https://brutal.elian.codes/'
+      ? 'https://emilia.gay/'
       : process.env.VERCEL_URL
       ? `https://${process.env.VERCEL_URL}/`
       : 'https://localhost:3001/',

--- a/src/pages/feed.xml.js
+++ b/src/pages/feed.xml.js
@@ -15,6 +15,5 @@ export async function get(context) {
       link: `/blog/${post.slug}/`,
     })),
     customData: '<language>en-us</language>',
-    canonicalUrl: 'https://brutal.elian.codes',
   });
 }


### PR DESCRIPTION
## Changes

- Remove the canonicalUrl config option from the RSS config, because this option is [deprecated](https://github.com/withastro/roadmap/pull/232)
- Change the production site url

Please add the `VERCEL_ENV` environment variable in your [netlify dashboard](https://docs.netlify.com/environment-variables/overview/#app) and set this variable to "production". This makes sure the RSS feed gives back the correct site url to those consuming the feed.

Before (setting the env variable to production):
![image](https://github.com/wolfers/emiliagay/assets/55017867/215aa7f5-83fe-4d43-a2bc-2992e2aba498)

After (setting the env variable to production):
![image](https://github.com/wolfers/emiliagay/assets/55017867/68398fe0-e8db-4eab-bc8b-eda26ae49f15)


## Docs

Behind the scenes change.